### PR TITLE
NoPhase: restore double quotes for element attributes only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hangman",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "proxy": "http://localhost:3001/",
   "dependencies": {

--- a/src/Components/Gallows.js
+++ b/src/Components/Gallows.js
@@ -4,7 +4,7 @@ import { drawGallows } from './gallowsSvg';
 import './Gallows.css';
 
 const Gallows = ({ badGuesses }) =>
-  <svg id='gallows' ref={drawGallows(badGuesses.length)}></svg>
+  <svg id="gallows" ref={drawGallows(badGuesses.length)}></svg>
 
 Gallows.propTypes = {
   badGuesses: PropTypes.string.isRequired

--- a/src/Components/Letter.js
+++ b/src/Components/Letter.js
@@ -19,7 +19,7 @@ const Letter = ({ letter, mode, onLetterChosen }) => {
 
   const renderButton = () =>
     <button
-      className='Letter-available'
+      className="Letter-available"
       onClick={() => onLetterChosen(letter)}
     >
       {letter}

--- a/src/Containers/App.js
+++ b/src/Containers/App.js
@@ -97,8 +97,8 @@ class App extends Component {
 
   render() {
     return (
-      <div className='App' ref={this.establishKeyPressHandler}>
-        <div className='App-version'>version: {version}</div>
+      <div className="App" ref={this.establishKeyPressHandler}>
+        <div className="App-version">version: {version}</div>
         <Gallows {...this.state} />
         <Word {...this.state} />
         <Letters {...this.state} onLetterChosen={this.onLetterChosen} />


### PR DESCRIPTION
A previous global replace of double quotes => single quotes also changed element attributes (obviously). I have put double quotes back for element attributes only.